### PR TITLE
refac: improving `update()` methods of synthetic data objects + extra refactoring

### DIFF
--- a/notebooks/examples/synthetic_data_dynamics.ipynb
+++ b/notebooks/examples/synthetic_data_dynamics.ipynb
@@ -1,0 +1,485 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Synthetic Data Dynamics\n",
+    "\n",
+    "Here we visualize the dynamics of our `Sample`, modelling division, death, ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ndv\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from cellgroup.synthetic.nucleus import Nucleus\n",
+    "from cellgroup.synthetic.cluster import Cluster\n",
+    "from cellgroup.synthetic.sample import Sample\n",
+    "from cellgroup.synthetic.space import Space\n",
+    "from cellgroup.synthetic.utils import Status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_2D_rendering(img: np.ndarray, grid: bool = True):\n",
+    "    \n",
+    "    fig, ax = plt.subplots()\n",
+    "    \n",
+    "    # Display the matrix as an image\n",
+    "    ax.imshow(img, cmap=\"gray\")\n",
+    "\n",
+    "    # Add grid lines\n",
+    "    if grid:\n",
+    "        ax.set_xticks(np.arange(0, img.shape[0], 1), minor=True)\n",
+    "        ax.set_yticks(np.arange(0, img.shape[1], 1), minor=True)\n",
+    "        ax.grid(which=\"minor\", color=\"red\", linestyle='-', linewidth=1)\n",
+    "        ax.grid(which=\"major\", color=\"red\", linestyle='-', linewidth=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Cell division"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "2D case"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "space = Space(size=(100, 100), scale=(1, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nucleus = Nucleus(\n",
+    "    idx=0,\n",
+    "    time=0,\n",
+    "    centroid = (30, 30),\n",
+    "    semi_axes=(8, 5),\n",
+    "    angle_x=45,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d1, d2 = nucleus.divide()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(d1), type(d2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img1 = nucleus.render(space)\n",
+    "img2 = d1.render(space)\n",
+    "img3 = d2.render(space)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_2D_rendering(img1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = img2 + img3\n",
+    "img.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nucleus._size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_2D_rendering(img)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d1._size + d2._size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "3D case"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "space = Space(size=(100, 100, 100), scale=(1, 1, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nucleus = Nucleus(\n",
+    "    idx=0,\n",
+    "    time=0,\n",
+    "    space=space,\n",
+    "    centroid = (30, 30, 30),\n",
+    "    semi_axes=(8, 5, 12),\n",
+    "    angle_x=0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d1, d2 = nucleus.divide()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img1 = nucleus.render()\n",
+    "img2 = d1.render()\n",
+    "img3 = d2.render()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v = ndv.imshow(img1.astype(np.uint8))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v2 = ndv.imshow((img2 + img3).astype(np.uint8))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Test `update()` for a `Nucleus`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "space = Space(size=(100, 100), scale=(1, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nucleus = Nucleus(\n",
+    "    idx=0,\n",
+    "    time=0,\n",
+    "    space=space,\n",
+    "    centroid = (30, 30),\n",
+    "    semi_axes=(5, 12),\n",
+    "    angle_x=0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Prior update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_2D_rendering(nucleus.render())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nucleus.update()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_2D_rendering(nucleus.render())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Test `Cluster` update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "space = Space(size=(500, 500), scale=(1, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster = Cluster.create_random_cluster(\n",
+    "    time=0,\n",
+    "    idx=0,\n",
+    "    space=space,\n",
+    "    n_nuclei=20,\n",
+    "    center=(200, 200),\n",
+    "    radii=(150, 150),\n",
+    "    semi_axes_range=(5, 15), \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_2D_rendering(cluster.render(), False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster.update()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_2D_rendering(cluster.render(), False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. Test `Sample` update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "space = Space(size=(500, 500, 500), scale=(1, 1, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample = Sample.create_random_sample(\n",
+    "    space=space,\n",
+    "    time=0,\n",
+    "    n_clusters=3,\n",
+    "    cluster_centers=[(80, 80, 80), (300, 300, 300), (400, 400, 400)],\n",
+    "    cluster_radii=[(50, 50, 50), (50, 50, 50), (50, 50, 50)],\n",
+    "    nuclei_per_cluster_range=[3, 10],\n",
+    "    nuclei_semi_axes_range=(5, 10),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = sample.render()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view = ndv.imshow(img)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Update sample"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample.update()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img_updated = sample.render()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view_updated = ndv.imshow(img_updated)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "cellgroup_env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/cellgroup/synthetic/cluster.py
+++ b/src/cellgroup/synthetic/cluster.py
@@ -213,7 +213,7 @@ class Cluster(BaseModel):
         self.nuclei = alive_nuclei
 
         # --- Apply inter-cluster forces
-        self.apply_forces()
+        # self.apply_forces()
     
 
     def render(self, border: bool = False) -> NDArray:

--- a/src/cellgroup/synthetic/cluster.py
+++ b/src/cellgroup/synthetic/cluster.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.typing import NDArray
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from cellgroup.synthetic.nucleus import Nucleus
+from cellgroup.synthetic.nucleus import Nucleus, Status
 from cellgroup.synthetic.space import Space
 
 
@@ -21,8 +21,9 @@ class Cluster(BaseModel):
     
     dead_nuclei: list[Nucleus] = Field(default_factory=list)
     "List of dead nuclei in the cluster."
-    # might be useful for analysis (e.g., lineage)
-    # it is more efficient to keep them separate than to avoid calling update() on them
+    
+    divided_nuclei: list[Nucleus] = Field(default_factory=list)
+    "List of nuclei in the cluster that have undergone division."
 
     # Geometric properties
     max_radius: tuple[int, ...]
@@ -150,33 +151,10 @@ class Cluster(BaseModel):
                 forces[j] = (forces[j][0] + force * dx, forces[j][1] + force * dy)
 
         return forces
-
-    def update(self):
-        """Update the status of nuclei in the cluster."""
-        if self.count == 0:
-            return
-
-        # Update individual nuclei
-        alive_nuclei = []
-        for nucleus in self.nuclei:
-            nucleus.update()
-            
-            #TODO: implement check for new position
-            
-            # Remove dead nuclei
-            if not nucleus.is_alive:
-                alive_nuclei.append(nucleus)                
-            else:
-                self.dead_nuclei.append(nucleus)
-
-            # Check for division #TODO: for coherence, this should happen in nucleus.update()
-            if nucleus.Area >= nucleus.min_division_size:
-                daughter = nucleus.divide()
-                if daughter != nucleus:
-                    alive_nuclei.append(daughter)
-
-        self.nuclei = alive_nuclei
-
+    
+    def apply_forces(self) -> None:
+        """Apply forces to nuclei in the cluster."""
+        raise NotImplementedError("Force application not implemented yet!")
         # Calculate and apply forces
         forces = self._calculate_forces()
 
@@ -199,6 +177,36 @@ class Cluster(BaseModel):
             nucleus.centroid = (int(new_x), int(new_y), 0)
             
             #TODO: can a nucleus be kicked out of the cluster due to repulsion?
+
+    def update(self) -> None:
+        """Update the status of nuclei in the cluster."""
+        if self.count == 0:
+            return
+
+        # --- Update individual nuclei
+        alive_nuclei = []
+        for nucleus in self.nuclei:
+            curr_status = nucleus.update()
+            
+            #TODO: implement check for new position (or at sample level)
+            
+            # --- Remove dead & divided nuclei
+            if curr_status == Status.ALIVE:
+                alive_nuclei.append(nucleus)                
+            elif curr_status == Status.DIVIDED:
+                # If nucleus has divided, compute the daugters
+                d1, d2 = nucleus.divide()
+                alive_nuclei.append(d1)
+                alive_nuclei.append(d2)
+                self.divided_nuclei.append(nucleus)
+            elif curr_status == Status.DEAD:
+                self.dead_nuclei.append(nucleus)
+
+        self.nuclei = alive_nuclei
+
+        # --- Apply inter-cluster forces
+        self.apply_forces()
+    
 
     def render(self, space: Space) -> NDArray:
         """Render the cluster."""

--- a/src/cellgroup/synthetic/nucleus.py
+++ b/src/cellgroup/synthetic/nucleus.py
@@ -148,10 +148,10 @@ class Nucleus(BaseModel):
     
     @model_validator(mode="after")
     def _validate_wrt_space(self):
-        if len(self.centroid) != self.space.ndim:
+        if len(self.centroid) != self.space.ndims:
             raise ValueError(
                 f"Centroid and space dimensions must match: "
-                f"{len(self.centroid)} != {self.space.ndim}."
+                f"{len(self.centroid)} != {self.space.ndims}."
             )
         return self
     

--- a/src/cellgroup/synthetic/nucleus.py
+++ b/src/cellgroup/synthetic/nucleus.py
@@ -342,9 +342,10 @@ class Nucleus(BaseModel):
         d2.semi_axes = self.semi_axes * scale_factor
 
         # --- Divide intensity roughly equally (with some noise)
-        intensity_ratio = np.random.normal(0.5, 0.05)
-        d1.raw_int_density *= intensity_ratio
-        d2.raw_int_density *= (1 - intensity_ratio)
+        if self.raw_int_density is not None:
+            intensity_ratio = np.random.normal(0.5, 0.05)
+            d1.raw_int_density *= intensity_ratio
+            d2.raw_int_density *= (1 - intensity_ratio)
 
         # --- Calculate new centroids position
         longest_axis_idx = np.argmax(self.semi_axes)

--- a/src/cellgroup/synthetic/sample.py
+++ b/src/cellgroup/synthetic/sample.py
@@ -69,7 +69,7 @@ class Sample(BaseModel):
     def centroid(self) -> tuple[float, ...]:
         """Calculate sample centroid."""
         if not self.clusters:
-            return (0.0, 0.0, 0.0) #TODO: adapt to 2D/3D
+            return (0.0,) * self.clusters.ndims #TODO: adapt to 2D/3D
 
         weighted_positions = [
             (c.centroid, c.count) for c in self.clusters
@@ -138,7 +138,7 @@ class Sample(BaseModel):
             self.clusters.append(new_cluster)
             
 
-    def update(self):
+    def update(self) -> None:
         """Update the status of clusters in the sample."""
         self.timestep += 1
 
@@ -158,7 +158,6 @@ class Sample(BaseModel):
         # Check for cluster merging
         self._merge_clusters()
 
-    #TODO: move to a separate class
     def render(self) -> NDArray:
         """Render the sample."""
         if not self.clusters:

--- a/src/cellgroup/synthetic/sample.py
+++ b/src/cellgroup/synthetic/sample.py
@@ -152,7 +152,7 @@ class Sample(BaseModel):
 
     def update(self) -> None:
         """Update the status of clusters in the sample."""
-        self.timestep += 1
+        self.time += 1
 
         # Update individual clusters
         active_clusters = []

--- a/src/cellgroup/synthetic/space.py
+++ b/src/cellgroup/synthetic/space.py
@@ -1,17 +1,17 @@
+from typing import Annotated
+
 import numpy as np
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, field_validator, model_validator, AfterValidator
 
 
 class Space(BaseModel):
     """Defines a space where synthetic data live."""
 
-    size: tuple[int, ...]
+    size: Annotated[tuple[int, ...], AfterValidator(lambda x: np.asarray(x))]
     "Size of space in pixels (Z, Y, X). Can be 2D or 3D."
 
-    scale: tuple[float, ...]
+    scale: Annotated[tuple[float, ...], AfterValidator(lambda x: np.asarray(x))]
     "Voxel size in each dimension in μm (Z, Y, X). Can be 2D or 3D."
-    
-    #TODO: private numpy attrs for speed-up (?) -> _size, _scale
     
     @field_validator('size')
     def validate_size(cls, value: tuple[int, ...]) -> tuple[int, ...]:

--- a/src/cellgroup/synthetic/space.py
+++ b/src/cellgroup/synthetic/space.py
@@ -39,7 +39,12 @@ class Space(BaseModel):
         return self
     
     @property
-    def ndim(self) -> int:
+    def is_3D(self) -> bool:
+        """Check if space is 3D."""
+        return len(self.size) == 3
+    
+    @property
+    def ndims(self) -> int:
         """Return number of dimensions (2D or 3D)."""
         return len(self.size)
 

--- a/src/cellgroup/synthetic/utils.py
+++ b/src/cellgroup/synthetic/utils.py
@@ -1,9 +1,5 @@
 """Utility functions for synthetic data generation."""
 from enum import Enum
-from typing import Any
-
-import numpy as np
-from numpy.typing import NDArray
 
 class Status(Enum):
     """Enumeration of nucleus status."""

--- a/src/cellgroup/synthetic/utils.py
+++ b/src/cellgroup/synthetic/utils.py
@@ -1,1 +1,15 @@
 """Utility functions for synthetic data generation."""
+from enum import Enum
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+class Status(Enum):
+    """Enumeration of nucleus status."""
+    ALIVE = "alive"
+    DEAD = "dead"
+    DIVIDED = "divided"
+    
+    def __str__(self):
+        return self.value


### PR DESCRIPTION
## Description

This PR mainly focuses on implementing the `update()` methods for `Nucleus`, `Cluster`, and `Sample` objects.
Specifically:
- `Nucleus`'s update applies shape changes (growth), displacements (move + rotation), parameter updating, and checks for death and division. The `update()` methods return a `Status` values that determines the current status of the object (among ALIVE, DIVIDE, DEAD).
- `Cluster`'s update simply calls the nucleus updates iteratively for each alive nucleus it contains.
- `Sample`'s update is similar to the one above.

### Additional changes

This PR also add the `space: Space` attribute in each of the classes above, so that all the entities in one simulation have all the overarching attributes in common (i.e., time, space). Finally, it implements classmethods to (almost completely) randomly create clusters and sample objects.

### Missing features

This PR doesn't contain everything it should. Indeed, many parts are left for future work. To mention some:
- Some methods weren't extended to 3D, hence they are marked with `NotImplementedError`.
- It did not assure that `time` and `space` info are correctly passed to all the instances in a simulation. To do so we'd need to do one or more of the following:
  1. Implement `model_validators` (however, we'd need to be careful, because in current pydantic model config, model validators would be called at every assignment to a class attribute).
  2. Simply ensure that in `update()` calls info is passed/shared correctly.
 - Currently, there is no way to uniquely create `idx` for nuclei and clusters. A solution would be to create an hash function that maps some unique nucleus/cluster feature to an hash code (this could be a nice little PR @guidoputignano).
 - Didn't check overall consistency of naming of methods/attrs between classes (e.g., `ndims` must always be present and called `ndims`, same for `is_3D` and the attributes too).